### PR TITLE
Fix bug in MutationOperator error message

### DIFF
--- a/ga/mutation_operator.py
+++ b/ga/mutation_operator.py
@@ -11,7 +11,7 @@ class MutationOperator:
         if MUTATION_METHOD == "random_swap":
             return self.random_swap()
         else:
-            raise ValueError(f"Unsupported mutation method: {self.method}")
+            raise ValueError(f"Unsupported mutation method: {MUTATION_METHOD}")
         
     def random_swap(self) -> np.ndarray:
         arr = self.chromosome


### PR DESCRIPTION
## Summary
- fix incorrect attribute reference in mutation method validation

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850321baee08329a3ef3eb0be24a851