### PR TITLE
Fix load_config path handling

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 from typing import Final, Dict, Tuple
+from pathlib import Path
+
 from enums.evaluation_method import EvaluationMethod
 from dataframes.subject import Subject
 from dataframes.curriculum import Curriculum
@@ -20,13 +22,25 @@ def load_config(
     rooms_csv: str = "csv/rooms.csv",
 ) -> Configuration:
     """Load scheduling configuration from CSV files."""
-    subjects = Subject(subjects_csv)
-    curriculum = Curriculum(curriculum_csv, subjects.df)
-    rooms = Room(rooms_csv)
+    base_path = Path(__file__).resolve().parent
 
-    coordinates = rooms.df.set_index("id")[["lat", "long"]].apply(tuple, axis=1).to_dict()
+    subjects_path = base_path / subjects_csv
+    curriculum_path = base_path / curriculum_csv
+    rooms_path = base_path / rooms_csv
+
+    subjects = Subject(subjects_path)
+    curriculum = Curriculum(curriculum_path, subjects.df)
+    rooms = Room(rooms_path)
+
+    coordinates = (
+        rooms.df.set_index("id")[["lat", "long"]]
+        .apply(tuple, axis=1)
+        .to_dict()
+    )
     sizes = rooms.df.set_index("id")["size"].to_dict()
-    total_duration = int((curriculum.df["classes"] * curriculum.df["credits"]).sum())
+    total_duration = int(
+        (curriculum.df["classes"] * curriculum.df["credits"]).sum()
+    )
     parallel_counts = tuple(curriculum.df["classes"])
 
     return Configuration(


### PR DESCRIPTION
## Summary
- ensure CSV paths resolve relative to globals.py

## Testing
- `python -m py_compile globals.py`
- `pytest -q` *(no tests found)*
- attempted to import `load_config` from a subdirectory but pandas was missing

------
https://chatgpt.com/codex/tasks/task_e_68560e33aac48329aa02006320232042